### PR TITLE
Add copy rules and word list pages

### DIFF
--- a/contents/components/copy-rules-sentence-case.html
+++ b/contents/components/copy-rules-sentence-case.html
@@ -1,0 +1,32 @@
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Conversational Headines</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>
+
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Text Links</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>
+
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Hover States</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>

--- a/contents/components/copy-rules-sentence-case.html
+++ b/contents/components/copy-rules-sentence-case.html
@@ -1,32 +1,23 @@
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Conversational Headines</p>
-  </div>
-  <div class="fl w-50-ns">
+<div class="cf mb3 nl2 nr2">
+  <div class="fl w-50-ns ph2">
     <figure>
       <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Conversational headines</figcaption>
+    </figure>
+  </div>
+  <div class="fl w-50-ns ph2">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Text links</figcaption>
     </figure>
   </div>
 </div>
 
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Text Links</p>
-  </div>
-  <div class="fl w-50-ns">
+<div class="cf mb3 nl2 nr2">
+  <div class="fl w-50-ns ph2">
     <figure>
       <img src="http://placekitten.com/g/600/400" alt="">
-    </figure>
-  </div>
-</div>
-
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Hover States</p>
-  </div>
-  <div class="fl w-50-ns">
-    <figure>
-      <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Hover states</figcaption>
     </figure>
   </div>
 </div>

--- a/contents/components/copy-rules-title-case.html
+++ b/contents/components/copy-rules-title-case.html
@@ -1,0 +1,43 @@
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Menu Labels</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>
+
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Page Titles</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>
+
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Navigation and Section Headers</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>
+
+<div class="cf mb3">
+  <div class="fl w-50-ns">
+    <p>Buttons</p>
+  </div>
+  <div class="fl w-50-ns">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+    </figure>
+  </div>
+</div>

--- a/contents/components/copy-rules-title-case.html
+++ b/contents/components/copy-rules-title-case.html
@@ -1,43 +1,29 @@
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Menu Labels</p>
-  </div>
-  <div class="fl w-50-ns">
+<div class="cf mb3 nl2 nr2">
+  <div class="fl w-50-ns ph2">
     <figure>
       <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Menu labels</figcaption>
+    </figure>
+  </div>
+  <div class="fl w-50-ns ph2">
+    <figure>
+      <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Page titles</figcaption>
     </figure>
   </div>
 </div>
 
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Page Titles</p>
-  </div>
-  <div class="fl w-50-ns">
+<div class="cf mb3 nl2 nr2">
+  <div class="fl w-50-ns ph2">
     <figure>
       <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Navigation and section headers</figcaption>
     </figure>
   </div>
-</div>
-
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Navigation and Section Headers</p>
-  </div>
-  <div class="fl w-50-ns">
+  <div class="fl w-50-ns ph2">
     <figure>
       <img src="http://placekitten.com/g/600/400" alt="">
-    </figure>
-  </div>
-</div>
-
-<div class="cf mb3">
-  <div class="fl w-50-ns">
-    <p>Buttons</p>
-  </div>
-  <div class="fl w-50-ns">
-    <figure>
-      <img src="http://placekitten.com/g/600/400" alt="">
+      <figcaption>Buttons</figcaption>
     </figure>
   </div>
 </div>

--- a/contents/copy-rules.html
+++ b/contents/copy-rules.html
@@ -1,0 +1,97 @@
+<header>
+  <h1>Copy Rules</h1>
+</header>
+
+<section>
+  <h2>Point of view</h2>
+  <p>
+    In general, use the second person (you) to address the user in Firefox products. Firefox is a user agent, and this point of view reinforces the message that “Firefox works for you.”
+  </p>
+  <p>
+    Avoid using the first person (my, I) in the interface, as it can create confusion about who is being addressed. 
+  </p>
+</section>
+
+<section>
+  <h2>Capitalisation</h2>
+
+  <h3>Title Case</h3>
+  <p>
+    Title case is a capitalization style that includes the following rules: 
+  </p>
+  <ul>
+    <li>
+      Always capitalize the first and last word in the text element, regardless of part of speech or other rules below
+    </li>
+    <li>
+      For words in between the first and last, capitaliize all nouns, verbs, adverbs and pronouns
+    </li>
+    <li>
+      Capitalize conjunctions of four or more letters, but also capitalize <em>if</em>
+    </li>
+    <li>
+      Capitalize prepositions for four or more letters
+    </li>
+    <li>
+      Do not capitalize articles, prepositions of three or fewer letters, and conjunctions of three or fewer letters (but not <em>if</em>)
+    </li>
+    <li>
+      A note about hyphens: Capitalize the second word in a hyphenated compound if it would normally be capitalized as a single word according to title case rules. So, capitalize the <em>S</em> in <em>Quick-Search Options</em>, lowercase the <em>o</em> in <em>Add-on Choices</em>. 
+    </li>
+  </ul>
+
+  <h3>When to use Title Case</h3>
+  <% include contents/components/copy-rules-title-case.html %>
+
+  <h3>Sentence Case</h3>
+  <p>
+    Sentence case is a capitalization style where the first word of the text element is capitalized as well as any words that are normally capitalized. 
+  </p>
+
+  <h3>When to use Sentence Case</h3>
+  <% include contents/components/copy-rules-sentence-case.html %>
+
+  <h3>Small Caps</h3>
+  <p>
+    Small caps is a style where the initial letter of every word is capitalized with a full-scale letter (following title case style) and the following letters in every word are capitalized with a smaller version of the typeface. Do not use this style in Firefox in any platform.
+  </p>
+</section>
+
+<section>
+  <h2>Punctuation</h2>
+
+  <h3>Commas</h3>
+  <p>
+    Do not use serial commas (also called Oxford commas) in Mozilla communications.
+  </p>
+
+  <h3>Dashes</h3>
+  <p>
+    Hyphens (-) are used to create a single idea out of two or more words and are used without letterspace; en dashes (–) are used for ranges, like numbers and dates, and are used without letterspace; em dashes (—) are used to set related, yet separate thoughts off from each other, either within a sentence or following it, and in either case they are separated by one letterspace to each side of the dash.
+  </p>
+
+  <h3>Ellipses</h3>
+  <p>
+    Use an ellipsis (…) in body text to indicate a pause in speech or thought; use with Button or Menu items when the action will require further user input (this usually results in either a Dialog, Alert or moving the operation to another window or part of the UI); do not use in a link to indicate that there is more information available at the destination, which should be assumed.
+  </p>
+
+  <h3>Exclamation Points</h3>
+  <p>
+    It’s acceptable to use exclamation points, but don’t overdo it; they are not a replacement for creating genuine excitement in writing.
+  </p>
+
+  <h3>Quotation Marks</h3>
+  <p>
+    Punctuation generally goes inside quotation marks, including exclamation and question marks, unless the exclamation or question is part of the entire sentence, not just the portion contained in the quotation marks.
+  </p>
+
+  <h3>Slashes</h3>
+  <p>
+    If it’s in a URL, it’s a forward slash, not a backslash.
+  </p>
+
+  <h3>Terminal Punctuation</h3>
+  <p>
+    Do not use punctuation at the end of a headline, button label, text link, or navigation element unless you are using an exclamation point or question mark or the link is embedded in running text.
+  </p>
+</section>

--- a/contents/index.json
+++ b/contents/index.json
@@ -31,13 +31,15 @@
     "title": "Motion",
     "pages": [
       {
-        "title": "Principles",
+        "title": "Motion Principles",
         "file": "motion-principles.html"
       }
     ]
   },
   {"title": "Copy",
     "pages": [
+      {"title": "Copy Rules",
+        "file": "copy-rules.html"}
     ]
   },
   {"title": "Patterns",
@@ -50,10 +52,8 @@
   },
   {"title": "Resources",
     "pages": [
-      {
-        "title": "Templates",
-        "file": "templates.html"
-      }
+      {"title": "Templates",
+        "file": "templates.html"}
     ]
   }
 ]

--- a/contents/index.json
+++ b/contents/index.json
@@ -39,7 +39,9 @@
   {"title": "Copy",
     "pages": [
       {"title": "Copy Rules",
-        "file": "copy-rules.html"}
+        "file": "copy-rules.html"},
+      {"title": "Word List",
+        "file": "word-list.html"}
     ]
   },
   {"title": "Patterns",

--- a/contents/word-list.html
+++ b/contents/word-list.html
@@ -1,0 +1,450 @@
+<header>
+  <h1>Word List</h1>
+</header>
+
+<section>
+  <h2>A</h2>
+  <h4>a11y</h4>
+  <p>
+    Our abbreviation for accessibility (11 letters between the A and Y), reserved for internal use or where space is a consideration, otherwise please avoid or explain on first use.
+  </p>
+  <h4>acronyms</h4>
+  <p>
+    Uppercase with no periods, unless they are specifically part of a brand name or the result spells out a different word.
+  </p>
+  <h4>add-ons</h4>
+  <p>
+    See “Firefox Add-ons”; note that add-ons is hyphenated, never “addons” AMO our internal name for addons.mozilla.org ; do not use in any user-facing communications.
+  </p>
+  <h4>Aurora</h4>
+  <p>
+    Our old internal name for Firefox Developer Edition; do not use in any user-facing communications.
+  </p>
+</section>
+
+<section>
+  <h2>B</h2>
+  <h4>Beta</h4>
+  <p>
+    See Firefox Beta.
+  </p>
+</section>
+
+<section>
+  <h2>C</h2>
+  <h4>capitalization</h4>
+  <p>
+    Unless there is an entry stating otherwise, please capitalize the following: brands and products (Mozilla, Firefox, Persona, Marketplace, etc.); features (Panorama, etc.); acronyms (URL, etc.). URLs themselves (mozilla.org , firefox.com , etc.) are lowercase. 
+  </p>
+  <h4>channels</h4>
+  <p>
+    Our term for the various builds of our products; please avoid in user-facing communications.
+  </p>
+  <h4>customers</h4>
+  <p>
+    Do not use: we refer to “users” or “people.”
+  </p>
+</section>
+
+<section>
+  <h2>D</h2>
+  <h4>data</h4>
+  <p>
+    treat data as a singular entity, i.e., data is sent, this data is available; not data are sent, these data are available. In general, avoid using data as a term when you can use the more friendly term information , or when you can be more specific about types of data, like browsing history, IP address or timestamp.
+  </p>
+  <h4>Do Not Track</h4>
+  <p>
+    capitalized when referring to the setting in privacy preferences.
+  </p>
+  <h4>double-click</h4>
+  <p>
+    hyphenated in all forms and uses.
+  </p>
+</section>
+
+<section>
+  <h2>E</h2>
+  <h4>email</h4>
+  <p>
+    One word, lowercase, no hyphen.
+  </p>
+  <h4>extension</h4>
+  <p>
+    A type of browser add-on; see also add-ons, themes.
+  </p>
+</section>
+
+<section>
+  <h2>F</h2>
+  <h4>features</h4>
+  <p>
+    Individual product features are capitalized, unless there is an entry stating otherwise
+  </p>
+  <h4>Fennec</h4>
+  <p>
+    Internal code name for our mobile efforts as a whole, does not refer to any specific product and should not be used in outbound messaging.
+  </p>
+  <h4>Final Release</h4>
+  <p>
+    Our internal name for the mainstream releases of Firefox and Thunderbird; do not use in user-facing communications.
+  </p>
+  <h4>Firefox</h4>
+  <p>
+    Make sure to clearly specify whether you are talking about the Firefox family of products or one of those products (i.e. the Firefox browser) specifically; always capitalized unless appearing as part of a URL.
+  </p>
+  <h4>Firefox Accounts</h4>
+  <p>
+    Accounts is capitalized when it follows Firefox, lowercase when on its own; it can be singular or plural as needed and is always localized.
+  </p>
+  <h4>Firefox Add-ons</h4>
+  <p>
+    Add-ons is capitalized when it follows Firefox, lowercase when on its own, though the O is always lowercase; it can be singular or plural as needed and is always localized.
+  </p>
+  <h4>Firefox Beta</h4>
+  <p>
+    Firefox Beta on first mention, Beta on subsequent mentions, always capitalized.
+  </p>
+  <h4>Firefox Beta for mobile</h4>
+  <p>
+    “Beta for mobile” is also acceptable, but never “mobile Beta;” mobile is always lowercase.
+  </p>
+  <h4>Firefox browser</h4>
+  <p>
+    Use this to differentiate from the Firefox family of products or from another specific Firefox product (Firefox Marketplace, Firefox OS, etc.); browser is always lowercase.
+  </p>
+  <h4>Firefox Developer Edition</h4>
+  <p>
+    Firefox Developer Edition on first mention, Developer Edition on subsequent mentions, both words always capitalized.
+  </p>
+
+  <h4>Firefox for Android</h4>
+  <p>
+    use this in most cases when referring to the mobile browser (see also “Firefox browser”); Android is always capitalized; never “Firefox Android,” “Firefox on Android” or any other variation.
+  </p>
+  <h4>Firefox for desktop</h4>
+  <p>
+    Use this to differentiate from the mobile browser (see also “Firefox browser”); desktop is always lowercase; never “desktop Firefox” or “Firefox desktop.”
+  </p>
+  <h4>Firefox for mobile</h4>
+  <p>
+    Mobile is always lowercase; never “mobile Firefox” or “Firefox mobile.”
+  </p>
+  <h4>Firefox Marketplace</h4>
+  <p>
+    Firefox Marketplace on first mention, Marketplace is acceptable on subsequent mentions, always capitalized; never “Mozilla Marketplace.”
+  </p>
+  <h4>Firefox Nightly</h4>
+  <p>
+    Firefox Nightly on first mention, Nightly on subsequent mentions, always capitalized.
+  </p>
+  <h4>Firefox OS</h4>
+  <p>
+    The official name of the project formerly known as Boot to Gecko (or B2G); always use the complete name; do not use “the Firefox OS” unless it is being treated as an adjective (e.g. the Firefox OS experience, the Firefox OS home screen, etc.).
+  </p>
+  <h4>Firefox Themes</h4>
+  <p>
+    Themes is capitalized when it follows Firefox, lowercase when on its own; it can be singular or plural as needed and is always localized; formerly “Firefox Personas.”
+  </p>
+  <h4>free</h4>
+  <p>
+    This one is tricky as it means both “without cost” and “without restrictions” in English, though there are separate words for these concepts in many other languages; please be very clear when using or avoid.
+  </p>
+  <h4>fullscreen</h4>
+  <p>
+    One word, lowercase, when referring to the view mode of the browser; use “entire screen,” “whole screen” or similar formulation in other cases.
+  </p>
+  <h4>FxOS</h4>
+  <p>
+    For internal usage, this is the official abbreviation of “Firefox OS,” but it should not be used in any external communications</h4>or internal usage, this is the official abbreviation of “Firefox OS,” but it should not be used in any external communications.
+  </p>
+</section>
+
+<section>
+  <h2>G</h2>
+  <h4>gear</h4>
+  <p>
+    Used to refer to any branded merchandise, be it Mozilla, Firefox or any of our other brands; please use instead of “swag” or “merchandise.”
+  </p>
+</section>
+
+<section>
+  <h2>H</h2>
+  <h4>http://</h4>
+  <p>
+    This should never appear before a URL in communications unless you are using it to demonstrate a complete hyperlink; see also www.
+  </p>
+</section>
+
+<section>
+  <h2>I</h2>
+  <h4>i18n</h4>
+  <p>
+    Our abbreviation for internationalization (18 letters between the I and N), reserved for internal use or where space is a consideration, otherwise please avoid or explain on first use.
+  </p>
+  <h4>Internet</h4>
+  <p>
+    Always capitalized.
+  </p>
+</section>
+
+<section>
+  <h2>J</h2>
+  <h4>Join Mozilla</h4>
+  <p>
+    Refers specifically to the fundraising campaign and should not be used in other contexts; both words are capitalized and “Join” should never become “Joins,” “Joining” or any other form of the word.
+  </p>
+</section>
+
+<section>
+  <h2>L</h2>
+  <h4>l10n</h4>
+  <p>
+    Our abbreviation for localization (10 letters between the L and N), reserved for internal use or where space is a consideration, otherwise please avoid or explain on first use.
+  </p>
+  <h4>left-click</h4>
+  <p>
+    Hyphenated in all forms and uses. 
+  </p>
+  <h4>location bar</h4>
+  <p>
+    Use this instead of address bar, awesome bar, or URL bar long-pressing.
+  </p>
+</section>
+
+<section>
+  <h2>H</h2>
+  <h4>hyphenate</h4>
+  <p>
+    (For clarity) when describing this emerging term for this mobile touch gestures.
+  </p>
+</section>
+
+<section>
+  <h2>M</h2>
+  <h4>malware</h4>
+  <p>
+    Malware, like software, is an uncountable noun, which means it does not take a plural form and cannot be associated with a number; you should never refer to “a malware” or “three malwares.”
+  </p>
+  <h4>merch/merchandise</h4>
+  <p>
+    Please use “gear” to refer to branded merchandise.
+  </p>
+  <h4>mobile</h4>
+  <p>
+    Lowercase, even if it follows Firefox; see also “Firefox for mobile.”
+  </p>
+  <h4>mobile device</h4>
+  <p>
+    In general, use this instead of “phone” or “tablet” unless you are purposely differentiating between the two mobile phone use only to differentiate from a tablet, otherwise use “mobile device” mobile tablet redundant, do not use.
+  </p>
+  <h4>Moz</h4>
+  <p>
+    We do not generally abbreviate the Mozilla name, unless otherwise noted in this guide; please avoid MozCamp/MozCamps regional gatherings of volunteer and paid staff that happen several times a year around the world (MozCamp Asia, MozCamp LatAm, etc.); note the capitalization.
+  </p>
+  <h4>Mozilla</h4>
+  <p>
+    Make sure Mozilla is well established early or prominently in any writing or communications (Tabzilla satisfies this requirement, for example), either as part of a product name (Mozilla Firefox, Mozilla Webmaker, etc.) or on its own, but do not use any compound constructions (like Mozilla Firefox Marketplace); even though the Mozilla wordmark is lowercase, Mozilla should be capitalized in all other uses, unless as part of a URL (mozilla.org).
+  </p>
+  <h4>Mozilla Reps</h4>
+  <p>
+    Always two words, always capitalized.
+  </p>
+  <h4>Mozilla Space/Spaces</h4>
+  <p>
+    Official terms for a specific group of Mozilla offices around the world, which include open space for the community; current locations or those in the works include San Francisco, Toronto, London, Berlin, Tokyo, Auckland, Beijing, Paris and Vancouver.
+  </p>
+  <h4>Mozilla Webmaker</h4>
+  <p>
+    Mozilla Webmaker on first mention, Webmaker on subsequent mentions, always capitalized.
+  </p>
+  <h4>Mozillians</h4>
+  <p>
+    Refers to paid staff or volunteers of the Mozilla project; always uppercase unless part of a URL (mozillians.org).
+  </p>
+  <h4>MozSpace/MozSpaces</h4>
+  <p>
+    Informal terms for Mozilla Spaces reserved for internal use; do not use in any communications.
+  </p>
+  </dl>
+</section>
+
+<section>
+  <h2>N</h2>
+  <h4>New Tab</h4>
+  <h4>New Window</h4>
+  <h4>non-profit</h4>
+  <p>
+    Though “nonprofit” is not incorrect, we prefer to use the hyphenated form
+  </p>
+  <h4>numbers</h4>
+  <p>
+    Spell out as words from one to nine, use numerals 10 and up; spell out large numbers like thousand, million, etc. (see also “version numbers”).
+  </p>
+</section>
+
+<section>
+  <h2>O</h2>
+  <h4>open/open Web</h4>
+  <p>
+    As the Web is open by its very nature, there is no need to make the distinction; not a forbidden term, but avoid where possible; when specifically and intentionally referring to the Open Web movement, please capitalize.
+  </p>
+</section>
+
+<section>
+  <h2>P</h2>
+  <h4>people</h4>
+  <p>
+    Though we mostly refer to “users,” this is also acceptable and either should be used instead of “customers.”
+  </p>
+  <h4>Personas</h4>
+  <p>
+    Use “Firefox Themes” instead; see that entry for usage details.
+  </p>
+  <h4>phone</h4>
+  <p>
+    See “mobile phone.”
+  </p>
+  <h4>possessives</h4>
+  <p>
+    Though you may run into cases where it’s impossible, please avoid using possessives with our brands or product names where you can; see also “plurals.”
+  </p>
+
+  <h4>plugin/plugins</h4>
+  <p>
+    Unless you're talking about physically plugging something in, this should be one word, lowercase, when referring to things like Flash and QuickTime.
+  </p>
+  <h4>plurals</h4>
+  <p>
+    As with possessives, it is preferable not to pluralize our brands or product names; try to reword if you can.
+  </p>
+  <h4>preferences</h4>
+  <p>
+    Use preferences (instead of settings) for Firefox desktop on Mac to conform with the platform; see also, settings.
+  </p>
+  <h4>Private Browsing</h4>
+  <h4>Private Tab</h4>
+  <h4>Private Window</h4>
+  <h4>product numbers</h4>
+  <p>
+    See “version numbers.”
+  </p>
+  <h4>punctuation</h4>
+  <p>
+    See punctuation section below.
+  </p>
+</section>
+
+<section>
+  <h2>R</h2>
+  <h4>release numbers</h4>
+  <p>
+    See “version numbers.”
+  </p>
+  <h4>ReMo</h4>
+  <p>
+    Our internal codename for Mozilla Reps; do not use in any user-facing communications.
+  </p>
+  <h4>right-click</h4>
+  <p>
+    Hyphenated in all forms and uses.
+  </p>
+</section>
+
+<section>
+  <h2>S</h2>
+  <h4>settings</h4>
+  <p>
+    Use settings (instead of options) for Firefox desktop on Windows, Firefox for Android and Firefox for iOS to conform with the platforms; see also, preferences.
+  </p>
+  <h4>site</h4>
+  <p>
+    Site is an acceptable term to refer to a website; see also website.
+  </p>
+  <h4>SUMO</h4>
+  <p>
+    Our internal name for support.mozilla.org; do not use in any user-facing communications.
+  </p>
+  <h4>swag</h4>
+  <p>
+    Please use “gear” to refer to branded merchandise.
+  </p>
+  <h4>Start Page</h4>
+  <h4>Sync</h4>
+  <p>
+    Capitalized when talking about the feature in Firefox, lowercase when using it only as a descriptive term; avoid “Firefox Sync” where possible; variants are syncing, synced.
+  </p>
+</section>
+
+<section>
+  <h2>T</h2>
+  <h4>tablet</h4>
+  <p>
+    Use primarily to differentiate from a phone, otherwise use “mobile device” where possible.
+  </p>
+  <h4>Tabzilla</h4>
+  <p>
+    Our internal name for the Mozilla universal tab that appears at the top of our sites; avoid using in user-facing communications or explain on first reference.
+  </p>
+  <h4>themes</h4>
+  <p>
+    See “Firefox Themes.”
+  </p>
+  <h4>toolbar</h4>
+  <h4>Tracking Protection</h4>
+  <p>
+    Do not make specific reference to advertising or ad-blocking when describing. 
+  </p>
+</section>
+
+<section>
+  <h2>U</h2>
+  <h4>URL</h4>
+  <p>
+    All uppercase, no periods, but URLs themselves (mozilla.org , firefox.com , etc.) are lowercase.
+  </p>
+  <h4>users</h4>
+  <p>
+    Use this or “people” instead of “customers.”
+  </p>
+</section>
+
+<section>
+  <h2>V</h2>
+  <h4>version numbers</h4>
+</section>
+
+<section>
+  <h2>W</h2>
+  <h4>Web</h4>
+  <p>
+    Always capitalized when on its own or part of a compound construction that doesn’t create a new word (Web page, Web feed, etc.); see individual entries for other uses.
+  </p>
+  <h4>webcam</h4>
+  <p>
+    One word, lowercase.
+  </p>
+  <h4>webcast</h4>
+  <p>
+    One word, lowercase.
+  </p>
+  <h4>WebFWD</h4>
+  <p>
+    Please note the capitalization, unless dealing with a URL (webfwd.org).
+  </p>
+  <h4>webmaster</h4>
+  <p>
+    One word, lowercas.
+  </p>
+  <h4>Web Push</h4>
+  <p>
+    Capitalize when referring to the notification standard.
+  </p>
+  <h4>website</h4>
+  <p>
+    One word, lowercase; do not use web site.
+  </p>
+  <h4>www</h4>
+  <p>
+    Avoid using before URLs; modern browsers (and modern users) will assume the www.
+  </p>
+</section>


### PR DESCRIPTION
Suggested by Michelle I port the copy rules and the word list pages from the [old style guide](https://firefoxux.github.io/StyleGuide/#/copyrules).

@TLHuang Michelle suggested to redo the images. I add kitten placeholders where we may need them. As discussed previously I believe that these visuals can be abstract. 