### PR TITLE
[fix] seperate AMO from add-ons

### DIFF
--- a/contents/word-list.html
+++ b/contents/word-list.html
@@ -15,7 +15,11 @@
   </p>
   <h4>add-ons</h4>
   <p>
-    See “<a href="#firefox-add-ons">Firefox Add-ons</a>”; note that "add-ons" is hyphenated, never “addons” AMO our internal name for addons.mozilla.org; do not use in any user-facing communications.
+    See “<a href="#firefox-add-ons">Firefox Add-ons</a>”; note that "add-ons" is hyphenated, never “addons”.
+  </p>
+  <h4>AMO</h4>
+  <p>
+    Our internal name for addons.mozilla.org; do not use in any user-facing communications.
   </p>
   <h4>Aurora</h4>
   <p>


### PR DESCRIPTION
looks like this was accidentally combined when creating the word-list...